### PR TITLE
ボリューム調整機能を追加

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use crate::{
-    analyzer::{Analyzer, CHUNK_SIZE},
+    analyzer::{Analyzer, AnalyzerOptions, CHUNK_SIZE},
     sound_device::DeviceList,
     utils,
 };
@@ -11,6 +11,7 @@ use egui_plot::{Bar, BarChart, Line, Plot, PlotPoints};
 pub struct App {
     device_list: DeviceList,
     analyzer: Option<Analyzer>,
+    analyzer_options: AnalyzerOptions,
     force_show_graph: bool,
 }
 
@@ -19,6 +20,7 @@ impl Default for App {
         Self {
             device_list: DeviceList::new(),
             analyzer: None,
+            analyzer_options: Default::default(),
             force_show_graph: false,
         }
     }
@@ -49,7 +51,7 @@ impl App {
 
     fn start(&mut self) {
         let capturer = self.device_list.device().capturer(CHUNK_SIZE);
-        let analyzer = Analyzer::new(capturer);
+        let analyzer = Analyzer::new(capturer, self.analyzer_options);
         self.analyzer = analyzer.into();
     }
 
@@ -92,7 +94,7 @@ impl eframe::App for App {
         if (self.force_show_graph || is_focused) && self.is_running() {
             let analyzer = self.analyzer.as_ref().unwrap();
             update_bottom(analyzer, ctx);
-            update_main(analyzer, ctx);
+            update_main(analyzer, &mut self.analyzer_options.gain, ctx);
             ctx.request_repaint();
         } else {
             egui::CentralPanel::default().show(ctx, |ui| {
@@ -105,7 +107,7 @@ impl eframe::App for App {
     }
 }
 
-fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
+fn update_main(analyzer: &Analyzer, gain: &mut f32, ctx: &egui::Context) {
     let freq_history = analyzer.results.freq_history_in_midi_note();
     let history_len = freq_history.len() as f64;
     let pitch_points: PlotPoints = freq_history
@@ -127,12 +129,19 @@ fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
         .collect();
     let spec = Line::new("pitch", spec_points).color(egui::Color32::CYAN);
 
-    let gain = utils::normalize(analyzer.results.volume_db(), -40.0, 0.0).clamp(0.0, 1.0);
-    let progress_bar: egui::ProgressBar = egui::ProgressBar::new(gain)
+    let volume_normalized =
+        utils::normalize(analyzer.results.volume_db(), -40.0, 0.0).clamp(0.0, 1.0);
+    let progress_bar: egui::ProgressBar = egui::ProgressBar::new(volume_normalized)
         .desired_height(10.0)
         .corner_radius(1);
 
     egui::CentralPanel::default().show(ctx, |ui| {
+        ui.style_mut().spacing.slider_width = 280.0;
+        let slider = egui::Slider::new(gain, -24.0..=24.0).suffix("dB");
+        let resp = ui.add(slider);
+        if resp.changed() {
+            analyzer.options.write().unwrap().gain = *gain;
+        }
         ui.add(progress_bar);
         ui.add_space(10.0);
         Plot::new("plot")

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,7 +105,7 @@ impl eframe::App for App {
 }
 
 fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
-    let freq_history = analyzer.freq_history_in_midi_note();
+    let freq_history = analyzer.results.freq_history_in_midi_note();
     let history_len = freq_history.len() as f64;
     let pitch_points: PlotPoints = freq_history
         .into_iter()
@@ -116,7 +116,7 @@ fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
         .color(egui::Color32::YELLOW)
         .width(3.0);
 
-    let spectrum = analyzer.spectrum();
+    let spectrum = analyzer.results.spectrum();
     let spec_points: PlotPoints = spectrum
         .into_iter()
         .map(|(midinote, gain)| {
@@ -140,7 +140,7 @@ fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
 }
 
 fn update_bottom(analyzer: &Analyzer, ctx: &egui::Context) {
-    let gains = analyzer.gains();
+    let gains = analyzer.results.gains();
     let gains_bars: Vec<Bar> = gains
         .into_iter()
         .enumerate()
@@ -160,7 +160,7 @@ fn update_bottom(analyzer: &Analyzer, ctx: &egui::Context) {
         });
 
     let (min, max) = (-30.0, 20.0);
-    let formant_spec = analyzer.formant_spec();
+    let formant_spec = analyzer.results.formant_spec();
     let formant_points: PlotPoints = formant_spec
         .into_iter()
         .enumerate()
@@ -168,7 +168,7 @@ fn update_bottom(analyzer: &Analyzer, ctx: &egui::Context) {
         .collect();
     let formantspec_line = Line::new("formant", formant_points);
 
-    let spectrum = analyzer.spectrum();
+    let spectrum = analyzer.results.spectrum();
     let spec_points: PlotPoints = spectrum
         .into_iter()
         .map(|(midinote, gain)| {
@@ -179,7 +179,7 @@ fn update_bottom(analyzer: &Analyzer, ctx: &egui::Context) {
         .collect();
     let spec = Line::new("pitch", spec_points).color(egui::Color32::CYAN);
 
-    let peaks = analyzer.formant_peak();
+    let peaks = analyzer.results.formant_peak();
     let colors = [
         egui::Color32::RED,
         egui::Color32::GREEN,

--- a/src/app.rs
+++ b/src/app.rs
@@ -119,7 +119,7 @@ fn update_main(analyzer: &Analyzer, gain: &mut f32, ctx: &egui::Context) {
         .color(egui::Color32::YELLOW)
         .width(3.0);
 
-    let spectrum = analyzer.results.spectrum();
+    let spectrum = analyzer.results.spectrum_in_midi_note();
     let spec_points: PlotPoints = spectrum
         .into_iter()
         .map(|(midinote, gain)| {
@@ -176,23 +176,18 @@ fn update_bottom(analyzer: &Analyzer, ctx: &egui::Context) {
                 });
         });
 
-    let (min, max) = (-30.0, 20.0);
+    let (min, max) = (-80.0, 60.0);
     let formant_spec = analyzer.results.formant_spec();
     let formant_points: PlotPoints = formant_spec
         .into_iter()
-        .enumerate()
-        .map(|(x, y)| [48_000.0 / 4.0 / 512.0 * x as f64, y.clamp(min, max)])
+        .map(|(freq, gain)| [freq, utils::to_db(gain).clamp(min, max)])
         .collect();
     let formantspec_line = Line::new("formant", formant_points);
 
     let spectrum = analyzer.results.spectrum();
     let spec_points: PlotPoints = spectrum
         .into_iter()
-        .map(|(midinote, gain)| {
-            let freq = 440.0 * 2.0_f32.powf((midinote - 69.0) / 12.0) as f64;
-            let gain = (gain as f64 + 6.02).clamp(min, max);
-            [freq, gain]
-        })
+        .map(|(freq, gain)| [freq as f64, utils::to_db(gain as f64).clamp(min, max)])
         .collect();
     let spec = Line::new("pitch", spec_points).color(egui::Color32::CYAN);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use crate::{
     analyzer::{Analyzer, CHUNK_SIZE},
     sound_device::DeviceList,
+    utils,
 };
 use eframe::egui;
 use egui_plot::{Bar, BarChart, Line, Plot, PlotPoints};
@@ -126,7 +127,14 @@ fn update_main(analyzer: &Analyzer, ctx: &egui::Context) {
         .collect();
     let spec = Line::new("pitch", spec_points).color(egui::Color32::CYAN);
 
+    let gain = utils::normalize(analyzer.results.volume_db(), -40.0, 0.0).clamp(0.0, 1.0);
+    let progress_bar: egui::ProgressBar = egui::ProgressBar::new(gain)
+        .desired_height(10.0)
+        .corner_radius(1);
+
     egui::CentralPanel::default().show(ctx, |ui| {
+        ui.add(progress_bar);
+        ui.add_space(10.0);
         Plot::new("plot")
             .show_x(false)
             .y_axis_formatter(|g, _r| midi_note_number_to_str(g.value))

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod analyzer;
 mod app;
 mod osc;
 mod sound_device;
+mod utils;
 
 fn main() -> eframe::Result {
     wasapi::initialize_mta().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+use rustfft::num_traits::Num;
+
+pub fn normalize<T: Num + Copy>(v: T, min: T, max: T) -> T {
+    (v - min) / (max - min)
+}
+
+pub fn lerp<T: Num + Copy>(a: T, b: T, t: T) -> T {
+    a + (b - a) * t
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use rustfft::num_traits::Num;
+use rustfft::num_traits::{Float, Num};
 
 pub fn normalize<T: Num + Copy>(v: T, min: T, max: T) -> T {
     (v - min) / (max - min)
@@ -6,4 +6,12 @@ pub fn normalize<T: Num + Copy>(v: T, min: T, max: T) -> T {
 
 pub fn lerp<T: Num + Copy>(a: T, b: T, t: T) -> T {
     a + (b - a) * t
+}
+
+pub fn to_db<T: Float>(v: T) -> T {
+    v.log10() * T::from(20.0).unwrap()
+}
+
+pub fn from_db<T: Float>(db: T) -> T {
+    T::from(20.0).unwrap().powf(db / T::from(20.0).unwrap())
 }


### PR DESCRIPTION
上のほうにボリュームメータとボリューム調整スライダーをいれたよ

<img width="363" height="514" alt="image" src="https://github.com/user-attachments/assets/3ee9742a-56ee-4894-846c-2cca7c5a3297" />

他のこまごました修正

- Mutex を使ってたところを RwLock に
- スペクトラムの縦軸を dB 単位に
  - osc で送る値に変化はない
  - 今までは底が e だったけど 10 にした
  - ボリュームが dB 単位なのであわせておきたい
